### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/markdown_pdf_renderer/cli.py
+++ b/src/markdown_pdf_renderer/cli.py
@@ -6,10 +6,22 @@ from typing import Literal, Optional
 
 import click
 
-from .renderer import render
+from . import __version__
 
 
 @click.command()
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=lambda ctx, param, value: (
+        click.echo(f"md-pdf {__version__}") or ctx.exit()
+        if value and not ctx.resilient_parsing
+        else None
+    ),
+    help="Show the version and exit.",
+)
 @click.argument("input_file", type=click.Path(exists=True, path_type=Path))
 @click.argument("output_file", type=click.Path(path_type=Path))
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,5 @@
 """Test CLI interface."""
 
-import sys
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
 from click.testing import CliRunner
 from markdown_pdf_renderer.cli import main
@@ -23,6 +19,11 @@ class TestCLI:
         assert result.exit_code == 0
         assert "INPUT_FILE" in result.output
         assert "OUTPUT_FILE" in result.output
+
+    def test_cli_version(self, runner):
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert result.output == "md-pdf 0.1.0\n"
 
     def test_cli_file_not_found(self, runner, temp_dir):
         result = runner.invoke(main, [temp_dir / "nonexistent.md", temp_dir / "out.pdf"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import pytest
 from click.testing import CliRunner
+from markdown_pdf_renderer import __version__
 from markdown_pdf_renderer.cli import main
 
 
@@ -23,7 +24,7 @@ class TestCLI:
     def test_cli_version(self, runner):
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert result.output == "md-pdf 0.1.0\n"
+        assert result.output == f"md-pdf {__version__}\n"
 
     def test_cli_file_not_found(self, runner, temp_dir):
         result = runner.invoke(main, [temp_dir / "nonexistent.md", temp_dir / "out.pdf"])


### PR DESCRIPTION
## Summary
- Run ID: `run-20260427-054002-8de5d6b3`
- Issue: `cracklings3d/markdown-pdf-renderer#9`
- Governance verdict: `approved`
