### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/markdown_pdf_renderer/cli.py
+++ b/src/markdown_pdf_renderer/cli.py
@@ -6,10 +6,11 @@ from typing import Literal, Optional
 
 import click
 
-from .renderer import render
+from . import __version__
 
 
 @click.command()
+@click.version_option(version=__version__)
 @click.argument("input_file", type=click.Path(exists=True, path_type=Path))
 @click.argument("output_file", type=click.Path(path_type=Path))
 @click.option(


### PR DESCRIPTION
## Provisional Summary
- Run ID: `run-20260428-012411-5e87af7f`
- Issue: `cracklings3d/markdown-pdf-renderer#9`
- Governance verdict: `provisional`
- Quality state: `provisional` (baseline-tolerant, not fully green)
